### PR TITLE
Fix typo & bugs about weight decay

### DIFF
--- a/methods/sprompt.py
+++ b/methods/sprompt.py
@@ -29,10 +29,6 @@ class SPrompts(BaseLearner):
 
         self.args = args
         self.EPSILON = args["EPSILON"]
-        self.init_epoch = args["init_epoch"]
-        self.init_lr = args["init_lr"]
-        self.init_lr_decay = args["init_lr_decay"]
-        self.init_weight_decay = args["init_weight_decay"]
         self.epochs = args["epochs"]
         self.lrate = args["lrate"]
         self.lrate_decay = args["lrate_decay"]
@@ -90,16 +86,12 @@ class SPrompts(BaseLearner):
             if param.requires_grad:
                 enabled.add(name)
         print(f"Parameters to be updated: {enabled}")
-        if self._cur_task==0:
-            optimizer = optim.SGD(self._network.parameters(), momentum=0.9,lr=self.init_lr,weight_decay=self.init_weight_decay)
-            scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer=optimizer,T_max=self.init_epoch)
-            self.run_epoch = self.init_epoch
-            self.train_function(train_loader,test_loader,optimizer,scheduler)
-        else:
-            optimizer = optim.SGD(self._network.parameters(), momentum=0.9,lr=self.lrate,weight_decay=self.weight_decay)
-            scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer=optimizer,T_max=self.epochs)
-            self.run_epoch = self.epochs
-            self.train_function(train_loader, test_loader, optimizer, scheduler)
+
+        optimizer = optim.SGD(filter(lambda p: p.requires_grad, self._network.parameters(
+            )), momentum=0.9,lr=self.lrate,weight_decay=self.weight_decay)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer=optimizer,T_max=self.epochs)
+        self.run_epoch = self.epochs
+        self.train_function(train_loader, test_loader, optimizer, scheduler)
 
 
     def train_function(self, train_loader, test_loader, optimizer, scheduler):


### PR DESCRIPTION
Hi, thanks for your repo.

I found some typos and bugs in the repo.

For instance, I have changed the `self._network.parameters()` to `filter(lambda p: p.requires_grad, self._network.parameters(
            ))`. Note that if you do not use the filter function to drop those  parameters that do not require updates, the weight decay in your optimizer will still change their value even though you have set them as `requires_grad=False`.  

I printed out the mean value of `prompt_pool[0].mean()` when learning `task 5`, you can see that it was decreasing. 

![image](https://user-images.githubusercontent.com/60997859/203994896-28db7de4-9d26-4753-bf9e-ac41961872ac.png)
